### PR TITLE
Change role to alumni and update description

### DIFF
--- a/_members/tom-roper.md
+++ b/_members/tom-roper.md
@@ -6,9 +6,10 @@ aliases:
 image: images/Team/tom-picture-cropped.jpeg
 description: 
 role: ra
+group: alumni
 links:
   github: tomroper09
   
 ---
 
-Tom is a research assistant on a BBSRC-funded project to study the learning algorithms underlying foraging decisions.
+Tom was a research assistant on a BBSRC-funded project to study the learning algorithms underlying foraging decisions.


### PR DESCRIPTION
Updated Tom Roper's role to 'alumni' and modified description.

This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
